### PR TITLE
fix: プレビュー機能のセキュリティを強化

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# microCMS
+MICROCMS_SERVICE_DOMAIN=your-service-domain
+MICROCMS_API_KEY=your-api-key
+
+# Base URL
+NEXT_PUBLIC_BASE_URL=https://your-domain.com
+
+# Google Analytics
+NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+
+# Preview Security (カンマ区切りで複数指定可能)
+# 本番環境でプレビューを許可するホストを指定
+ALLOWED_PREVIEW_HOSTS=your-domain.com,preview.your-domain.com
+
+# Node Environment
+NODE_ENV=development

--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -13,18 +13,36 @@ export async function GET(request: NextRequest) {
 
   const data = await getByContentIdAndDraftKey(slug, draftKey);
   if (!data) {
-    return NextResponse.json({ message: "Invalid slug" }, { status: 400 });
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 
   const contestId = data.id ?? "-1";
 
-  const response = NextResponse.redirect(`${ROUTE.postDetail(contestId)}`, 307);
+  // ホワイトリスト方式でリダイレクト先を制限
+  const allowedHosts = process.env.ALLOWED_PREVIEW_HOSTS?.split(",") || ["localhost:3000"];
+  const requestHost = nextUrl.host;
+
+  if (process.env.NODE_ENV === "production" && !allowedHosts.includes(requestHost)) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${nextUrl.protocol}//${requestHost}`;
+  const redirectUrl = new URL(ROUTE.postDetail(contestId), baseUrl);
+
+  const response = NextResponse.redirect(redirectUrl, 307);
   response.cookies.set(
     "__previewData",
     JSON.stringify({
       slug: contestId,
       draftKey: draftKey,
-    })
+    }),
+    {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+      maxAge: 60 * 60, // 1時間
+      path: "/",
+    }
   );
 
   return response;


### PR DESCRIPTION
## 概要
プレビュー機能で発生していた500エラーを修正し、同時にセキュリティを強化しました。

## 問題
- `NextResponse.redirect()`に相対URLを渡していたため、`URL is malformed`エラーが発生
- セキュリティ面での懸念事項が複数存在

## 変更内容
### 1. URL生成の修正
- 絶対URLを生成するように修正
- `NEXT_PUBLIC_BASE_URL`環境変数または自動検出でベースURLを設定

### 2. セキュリティ強化
- **Open Redirect脆弱性対策**: ホワイトリスト方式でリダイレクト先を制限
- **Cookie セキュリティ**: httpOnly, secure, sameSite属性を追加
- **情報漏洩対策**: エラーメッセージを一般化

### 3. 環境変数設定例の追加
- `.env.example`ファイルを作成
- `ALLOWED_PREVIEW_HOSTS`の設定方法を記載

## テスト項目
- [ ] draftKeyを使用したプレビューが正常に動作すること
- [ ] 本番環境で未許可のホストからのアクセスが拒否されること
- [ ] Cookieが適切なセキュリティ属性で設定されること

## 環境変数の設定
本番環境では以下の環境変数を設定してください：
```
ALLOWED_PREVIEW_HOSTS=blog.daisukekonishi.com
```

🤖 Generated with [Claude Code](https://claude.ai/code)