### PR TITLE
メタデータ整備とプレビュー導線分離でISR方針を統一

### DIFF
--- a/src/app/api/preview/route.ts
+++ b/src/app/api/preview/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: "Invalid request" }, { status: 400 });
   }
 
-  const contestId = data.id ?? "-1";
+  const contentId = data.id ?? "-1";
 
   // ホワイトリスト方式でリダイレクト先を制限
   const allowedHosts = process.env.ALLOWED_PREVIEW_HOSTS?.split(",") || ["localhost:3000"];
@@ -27,7 +27,7 @@ export async function GET(request: NextRequest) {
   }
 
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || `${nextUrl.protocol}//${requestHost}`;
-  const redirectUrl = new URL(ROUTE.postDetail(contestId), baseUrl);
+  const redirectUrl = new URL(ROUTE.postPreview(contentId), baseUrl);
 
   // draftKeyをURLパラメータとして追加
   redirectUrl.searchParams.set("draftKey", draftKey);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ import { PostMapper } from "@/models/mapper/PostMapper";
 export const dynamic = "force-dynamic";
 
 const title = SITE.name;
-const description = "PengNoteのAboutページです";
+const description = SITE.description;
 const url = `${SITE.url}${ROUTE.top}`;
 export const metadata: Metadata = {
   title,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ export const dynamic = "force-dynamic";
 const title = SITE.name;
 const description = SITE.description;
 const url = `${SITE.url}${ROUTE.top}`;
+
 export const metadata: Metadata = {
   title,
   description,
@@ -25,16 +26,20 @@ export const metadata: Metadata = {
   },
 };
 
-const response = await getAllPost();
-const posts = PostMapper.list(response.contents);
+const fetchData = async () => {
+  const response = await getAllPost();
+  const posts = PostMapper.list(response.contents);
+  const pageNum = 1; // トップなので、1ページ目を確定
+  const maxPage = calcMaxPage(response.totalCount, POST_PER_PAGE);
 
-const pageNum = 1; // トップなので、1ページ目を確定
-const maxPage = calcMaxPage(response.totalCount, POST_PER_PAGE);
-
-export default function Page() {
-  return IndexPage({
+  return {
     posts,
     maxPage,
     pageNum,
-  });
+  };
+};
+
+export default async function Page() {
+  const props = await fetchData();
+  return IndexPage(props);
 }

--- a/src/app/post/[slug]/page.tsx
+++ b/src/app/post/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { BlogPostJsonLd } from "@/components/seo/BlogPostJsonLd";
 import { ROUTE } from "@/constants/route";
 import { SITE } from "@/constants/site";
 import { md } from "@/libs/markdown-it";
-import { getByContentIdAndDraftKey, getBySlug, getByTagId } from "@/libs/microcms";
+import { getBySlug, getByTagId } from "@/libs/microcms";
 import { PostMapper } from "@/models/mapper/PostMapper";
 import type { ApiPost, ApiTag } from "@/types/api/Post";
 import type { IPostItem } from "@/types/domain/Post";
@@ -15,11 +15,7 @@ import { generateBlogCardHTML } from "@/utilities/blogCardHtml";
 import { fetchMultipleOGP } from "@/utilities/ogp";
 
 export const dynamicParams = true;
-
-// searchParamsを使用するため動的レンダリングを有効化
-export const dynamic = "force-dynamic";
-
-export const revalidate = 1800; // 1800秒 = 30分
+export const revalidate = 3600; // 3600秒 = 1時間
 
 export async function generateStaticParams() {
   return [];
@@ -38,35 +34,19 @@ async function fetchRelatedPosts(tagId: ApiTag["id"], currentPostId: ApiPost["id
   return PostMapper.relatedPosts(filteredRelatedPosts);
 }
 
-const fetchData = cache(async (slug: string, draftKey?: string | null) => {
-  let postResponse: ApiPost | undefined;
-
-  // プレビューモードの場合（draftKeyがある場合）
-  if (draftKey) {
-    const res = await getByContentIdAndDraftKey(slug, draftKey);
-    if (!res) {
-      return {
-        post: undefined,
-        relatedPosts: [] as IPostItem[],
-      };
-    }
-    postResponse = res;
-  } else {
-    // 通常モードの場合
-    const res = await getBySlug(slug);
-    if (!res.contents || !res.contents.length) {
-      return {
-        post: undefined,
-        relatedPosts: [] as IPostItem[],
-      };
-    }
-    postResponse = res.contents[0];
+const fetchData = cache(async (slug: string) => {
+  const res = await getBySlug(slug);
+  if (!res.contents || !res.contents.length) {
+    return {
+      post: undefined,
+      relatedPosts: [] as IPostItem[],
+    };
   }
+  const postResponse = res.contents[0];
 
   const tagId = postResponse.tags.at(0)?.id;
   let relatedPosts: IPostItem[] = [];
-  // プレビューモードでは関連記事を取得しない
-  if (tagId && !draftKey) {
+  if (tagId) {
     relatedPosts = await fetchRelatedPosts(tagId, postResponse.id); // TODO: 処理を別実行できるようにする
   }
 
@@ -100,12 +80,10 @@ const fetchData = cache(async (slug: string, draftKey?: string | null) => {
 
 export const generateMetadata = async (props: PageProps<{ slug: string }>): Promise<Metadata> => {
   const params = await props.params;
-  const searchParams = await props.searchParams;
   const { slug } = params;
   if (!slug) return {};
 
-  const draftKey = searchParams?.draftKey as string | undefined;
-  const { post } = await fetchData(slug, draftKey);
+  const { post } = await fetchData(slug);
   if (!post) return {};
 
   const { title: postTitle, thumbnail, publishedAt, updatedAt, body } = post;
@@ -154,9 +132,7 @@ export const generateMetadata = async (props: PageProps<{ slug: string }>): Prom
 
 export default async function Page(props: PageProps<{ slug: string }>) {
   const params = await props.params;
-  const searchParams = await props.searchParams;
-  const draftKey = searchParams?.draftKey as string | undefined;
-  const { post, relatedPosts } = await fetchData(params.slug, draftKey);
+  const { post, relatedPosts } = await fetchData(params.slug);
   if (!post) {
     return null;
   }

--- a/src/app/post/page/[offset]/page.tsx
+++ b/src/app/post/page/[offset]/page.tsx
@@ -9,17 +9,18 @@ import { PostMapper } from "@/models/mapper/PostMapper";
 
 const title = "記事一覧";
 const description = "今までに書いた記事の一覧ページです";
+const url = `${SITE.url}${ROUTE.postList(1)}`;
 
 export const metadata: Metadata = {
   title,
   description,
   openGraph: {
     title,
-    url: `${SITE.url}/${ROUTE.postList(1)}`,
+    url,
     type: "website",
   },
   alternates: {
-    canonical: `${SITE.url}/${ROUTE.postList(1)}`,
+    canonical: url,
   },
 };
 

--- a/src/app/post/preview/[contentId]/page.tsx
+++ b/src/app/post/preview/[contentId]/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { PostDetailPage } from "@/components/page/PostDetail/PostDetail";
+import { md } from "@/libs/markdown-it";
+import { getByContentIdAndDraftKey } from "@/libs/microcms";
+import { PostMapper } from "@/models/mapper/PostMapper";
+import type { ApiPost } from "@/types/api/Post";
+import type { PageProps } from "@/types/page";
+import { extractBlogCardUrls, replaceBlogCardUrls } from "@/utilities/blogCard";
+import { generateBlogCardHTML } from "@/utilities/blogCardHtml";
+import { fetchMultipleOGP } from "@/utilities/ogp";
+
+export const dynamic = "force-dynamic";
+
+const NO_INDEX = {
+  index: false,
+  follow: false,
+} as const;
+
+const getDraftKey = (searchParams?: Record<string, string | string[] | undefined>) => {
+  const draftKey = searchParams?.draftKey;
+  if (typeof draftKey === "string") {
+    return draftKey;
+  }
+  if (Array.isArray(draftKey)) {
+    return draftKey[0];
+  }
+
+  return undefined;
+};
+
+const fetchPreviewPost = async (contentId: string, draftKey: string) => {
+  let postResponse: ApiPost;
+  try {
+    postResponse = await getByContentIdAndDraftKey(contentId, draftKey);
+  } catch {
+    return undefined;
+  }
+
+  const post = await PostMapper.detail(postResponse);
+  post.body = md.render(post.body);
+
+  const blogCardUrls = extractBlogCardUrls(post.body);
+  if (blogCardUrls.length > 0) {
+    try {
+      const urls = blogCardUrls.map((item) => item.url);
+      const ogpDataList = await fetchMultipleOGP(urls);
+
+      post.body = replaceBlogCardUrls(post.body, blogCardUrls, (url) => {
+        const ogpData = ogpDataList.find((data) => data.url === url);
+        return ogpData
+          ? generateBlogCardHTML(ogpData)
+          : `<a href="${url}" target="_blank" rel="noopener">${url}</a>`;
+      });
+    } catch (error) {
+      console.warn("ブログカード処理でエラーが発生しました:", error);
+    }
+  }
+
+  return post;
+};
+
+export const metadata: Metadata = {
+  title: "プレビュー画面",
+  description: "記事プレビュー画面です。",
+  robots: NO_INDEX,
+};
+
+export default async function Page(props: PageProps<{ contentId: string }>) {
+  const params = await props.params;
+  const searchParams = await props.searchParams;
+  const draftKey = getDraftKey(searchParams);
+  if (!draftKey) {
+    notFound();
+  }
+
+  const post = await fetchPreviewPost(params.contentId, draftKey);
+  if (!post) {
+    notFound();
+  }
+
+  return <PostDetailPage post={post} relatedPosts={[]} />;
+}

--- a/src/app/post/tags/page.tsx
+++ b/src/app/post/tags/page.tsx
@@ -8,7 +8,7 @@ import { getTags } from "@/libs/microcms";
 
 const title = "タグ一覧";
 const description = "記事に関連するタグの一覧ページです";
-const url = `${SITE.url}${ROUTE.top}`;
+const url = `${SITE.url}${ROUTE.tagList}`;
 
 export const dynamic = "force-dynamic";
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,7 +6,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      disallow: ["/api/ogp/*", "/api/preview/*"],
+      disallow: ["/api/ogp/*", "/api/preview/*", "/post/preview/"],
     },
     sitemap: `${SITE.url}/sitemap.xml`,
     host: SITE.url,

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -5,6 +5,7 @@ export const ROUTE = {
   postListBase: "/post/page",
   postList: (pageNum: number) => `/post/page/${pageNum}`,
   postDetail: (slug: string) => `/post/${encodeURIComponent(slug)}`,
+  postPreview: (contentId: string) => `/post/preview/${encodeURIComponent(contentId)}`,
 
   postTagListBy: (tagName: string) => `/post/tags/${tagName}`,
   postTagList: (tagName: string, pageNum: number) => `/post/tags/${tagName}/${pageNum}`,


### PR DESCRIPTION
## 概要
- 記事一覧とタグ一覧の canonical / OGP URL を修正
- トップページの description をサイト説明に修正
- トップページのデータ取得をページ内に移動
- 公開記事ページを ISR（revalidate: 3600）に寄せ、プレビュー導線を分離
- preview ページを noindex 化し、robots.txt に /post/preview/ を disallow 追加

## 変更詳細
- post page offset ルートのメタデータ URL 組み立てを統一
- post tags ルートの canonical を正しいパスへ修正
- post slug ルートから draftKey 分岐を除去し公開導線をシンプル化
- post preview contentId ルートを追加して draftKey プレビューを集約
- api preview は維持し、遷移先のみ preview ルートへ変更

## テスト
- pnpm type-check
- pnpm check
- pnpm test
（いずれも成功）