### PR TITLE
Pin actions to SHAs and add read permission in CI workflows

### DIFF
--- a/.github/workflows/develop-integlation.yml
+++ b/.github/workflows/develop-integlation.yml
@@ -10,32 +10,35 @@ env:
   MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
   MICROCMS_SERVICE_DOMAIN: ${{ secrets.MICROCMS_SERVICE_DOMAIN }}
 
+permissions:
+  contents: read
+
 jobs:
   devCheck:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@a8198c4bff370c8506180b035930dea56dbd5288 # v5
         with:
           version: 10
 
       - name: Install mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           experimental: true
           install: false
 
-      - name: Setup Go with mise version
+      - name: Setup Node.js version from mise
         run: |
           NODE_VERSION=$(mise list node --json | jq -r '.[0].version')
           echo "NODE_VERSION=$NODE_VERSION" >> $GITHUB_ENV
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: ${{ env.GO_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -49,4 +52,3 @@ jobs:
 
       - name: Test
         run: pnpm test:run
-

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -6,17 +6,20 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: master
 
       - name: deploy
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@16e87c0a08142b0d0d33b76aeaf20823c381b9b9 # v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}


### PR DESCRIPTION
### Motivation
- Ensure reproducible and auditable CI runs by pinning GitHub Action references to specific commit SHAs and by restricting workflow permissions.
- Fix mise setup step to read the Node.js version (not Go) from `mise` and use that value when configuring Node.js.

### Description
- Added `permissions: contents: read` to both `develop` and `production` workflow files to limit workflow privileges.
- Replaced loose action tags with specific commit SHAs for `actions/checkout`, `pnpm/action-setup`, `jdx/mise-action`, `actions/setup-node`, and `amondnet/vercel-action` to pin action versions.
- Renamed the mise-related step from `Setup Go with mise version` to `Setup Node.js version from mise` and switched `node-version` input to use the `NODE_VERSION` environment variable populated from `mise` instead of `GO_VERSION`.

### Testing
- No CI run results are included in this change, so no automated test outcomes are available from this PR.
- After these workflow changes, the `develop` job will execute `pnpm install --frozen-lockfile`, `pnpm check`, `pnpm type-check`, and `pnpm test:run` when triggered.
- The `production` workflow remains configured to deploy with the Vercel action using the pinned action SHA when triggered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1c0be58ec832daf80f39d15cb28c5)