### PR TITLE
[codex] GitHub Actionsの権限をjob単位で明示

### DIFF
--- a/.github/workflows/develop-integlation.yml
+++ b/.github/workflows/develop-integlation.yml
@@ -10,12 +10,13 @@ env:
   MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
   MICROCMS_SERVICE_DOMAIN: ${{ secrets.MICROCMS_SERVICE_DOMAIN }}
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   devCheck:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -6,12 +6,13 @@ on:
     branches:
       - master
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## 概要

GitHub Actions の workflow 権限を必要最小限に整理しました。

## 変更内容

- workflow 全体のデフォルト権限を `permissions: {}` に変更
- `actions/checkout` が必要な job にのみ `contents: read` を明示
- 対象 workflow:
  - `.github/workflows/develop-integlation.yml`
  - `.github/workflows/production-deploy.yml`

## 目的

workflow 全体に暗黙の `GITHUB_TOKEN` 権限を持たせず、job ごとに必要な読み取り権限だけを付与するためです。

## 動作確認

- `pnpm check`
- `pnpm type-check`
- `pnpm test`