### PR TITLE
[codex] 記事ページの可読性を改善

### DIFF
--- a/src/components/page/PostDetail/PostDetail.test.tsx
+++ b/src/components/page/PostDetail/PostDetail.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+
+import type { IPost, IPostItem } from "@/types/domain/Post";
+
+import { PostDetailPage } from "./PostDetail";
+
+const mockPost: IPost = {
+  id: "post-1",
+  slug: "sample-post",
+  title: "Sample Post",
+  body: `
+    <p>First paragraph</p>
+    <h2>Section title</h2>
+    <h3>Subsection title</h3>
+    <pre><code>const value = 1;</code></pre>
+    <ul><li>List item</li></ul>
+  `,
+  category: {
+    name: "Category",
+    slug: "category",
+  },
+  tags: [
+    {
+      name: "tag1",
+      slug: "tag1",
+    },
+  ],
+  thumbnail: null,
+  publishedAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-02T00:00:00.000Z",
+};
+
+describe("PostDetailPage", () => {
+  test("記事本文に可読性向けのレイアウトクラスが適用されること", () => {
+    render(<PostDetailPage post={mockPost} relatedPosts={[]} />);
+
+    const headerWrap = screen.getByTestId("post-header-wrap");
+    expect(headerWrap.className).toContain("tw:max-w-[48rem]");
+    expect(headerWrap.className).toContain("tw:mx-auto");
+
+    const bodyWrap = screen.getByTestId("post-body-wrap");
+    expect(bodyWrap.className).toContain("tw:max-w-[48rem]");
+    expect(bodyWrap.className).toContain("tw:mx-auto");
+
+    const body = screen.getByTestId("post-body");
+    expect(body.className).toContain("tw:max-w-none");
+    expect(body.className).toContain("tw:prose-p:leading-[1.9]");
+    expect(body.className).toContain("tw:prose-p:my-[1.4em]");
+    expect(body.className).toContain("tw:prose-h2:mt-16");
+    expect(body.className).toContain("tw:prose-h3:mt-10");
+    expect(body.className).toContain("tw:prose-pre:my-8");
+  });
+
+  test("主要な記事要素が表示されること", () => {
+    const relatedPosts: IPostItem[] = [
+      {
+        slug: "related-post",
+        title: "Related Post",
+        publishedAt: "2024-01-03",
+        tags: [
+          {
+            name: "tag2",
+            slug: "tag2",
+          },
+        ],
+      },
+    ];
+
+    render(<PostDetailPage post={mockPost} relatedPosts={relatedPosts} />);
+
+    expect(screen.getByRole("heading", { name: "Sample Post", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("First paragraph")).toBeInTheDocument();
+    expect(screen.getByText("Section title")).toBeInTheDocument();
+    expect(screen.getByText("Subsection title")).toBeInTheDocument();
+    expect(screen.getByText("List item")).toBeInTheDocument();
+    expect(screen.getByText("Related Post")).toBeInTheDocument();
+  });
+});

--- a/src/components/page/PostDetail/PostDetail.tsx
+++ b/src/components/page/PostDetail/PostDetail.tsx
@@ -23,35 +23,47 @@ export const PostDetailPage = ({ post, relatedPosts }: PostProps) => {
         <div className={clsx("tw:space-y-8")}>
           <article>
             <header>
-              <Heading>{post.title}</Heading>
-              <div className={clsx("tw:flex tw:justify-between tw:items-center")}>
-                <time className={clsx("tw:block")} dateTime={post.publishedAt}>
-                  {pubDate}
-                </time>
-                <div className="tw:flex-1 tw:justify-items-end">
-                  <TagList tags={post.tags} doLink />
+              <div className="tw:mx-auto tw:w-full tw:max-w-[48rem]" data-testid="post-header-wrap">
+                <Heading>{post.title}</Heading>
+                <div className={clsx("tw:flex tw:justify-between tw:items-center")}>
+                  <time className={clsx("tw:block")} dateTime={post.publishedAt}>
+                    {pubDate}
+                  </time>
+                  <div className="tw:flex-1 tw:justify-items-end">
+                    <TagList tags={post.tags} doLink />
+                  </div>
                 </div>
+                {post.thumbnail && (
+                  <img
+                    className={clsx("tw:w-full tw:object-scale-down tw:mt-10")}
+                    src={post.thumbnail.url}
+                    alt={`${post.title}のサムネイル`}
+                  />
+                )}
               </div>
-              {post.thumbnail && (
-                <img
-                  className={clsx("tw:w-full tw:object-scale-down tw:mt-10")}
-                  src={post.thumbnail.url}
-                  alt={`${post.title}のサムネイル`}
-                />
-              )}
             </header>
 
             <div
-              className={clsx(
-                "tw:prose tw:prose-slate",
-                // custom tailwindcss-typography
-                "tw:prose-a:transition-colors",
-                "tw:prose-a:hover:no-underline tw:prose-a:hover:text-primary tw:prose-a:hover:opacity-70",
-                "tw:max-w-full"
-              )}
-              // biome-ignore lint/security/noDangerouslySetInnerHtml: ブログ記事のHTML表示で必要
-              dangerouslySetInnerHTML={{ __html: post.body }}
-            />
+              className="tw:mx-auto tw:mt-10 tw:w-full tw:max-w-[48rem]"
+              data-testid="post-body-wrap"
+            >
+              <div
+                className={clsx(
+                  "tw:prose tw:prose-slate tw:max-w-none",
+                  // custom tailwindcss-typography
+                  "tw:prose-p:my-[1.4em] tw:prose-p:leading-[1.9]",
+                  "tw:prose-ul:my-6 tw:prose-ol:my-6 tw:prose-li:my-1",
+                  "tw:prose-h2:mt-16 tw:prose-h2:mb-6",
+                  "tw:prose-h3:mt-10 tw:prose-h3:mb-4",
+                  "tw:prose-pre:my-8 tw:prose-pre:px-5 tw:prose-pre:py-4 tw:prose-pre:leading-7",
+                  "tw:prose-a:transition-colors",
+                  "tw:prose-a:hover:no-underline tw:prose-a:hover:text-primary tw:prose-a:hover:opacity-70"
+                )}
+                data-testid="post-body"
+                // biome-ignore lint/security/noDangerouslySetInnerHtml: ブログ記事のHTML表示で必要
+                dangerouslySetInnerHTML={{ __html: post.body }}
+              />
+            </div>
           </article>
 
           <footer className="tw:border-t-[1px] tw:border-t-white tw:py-5">


### PR DESCRIPTION
## 概要

- 記事ページの本文幅・行間・余白を調整して可読性を改善
- 記事ヘッダーも本文と同じ幅に揃えて冒頭の視線のズレを軽減
- PostDetailPage のレイアウトクラスを検証するテストを追加

## 確認

- pnpm type-check
- pnpm check
- pnpm test
