### PR TITLE
Use Intl.DateTimeFormat for zero-padded date formatting and add tests

### DIFF
--- a/src/components/features/post/PostList/PostItem/PostItem.test.tsx
+++ b/src/components/features/post/PostList/PostItem/PostItem.test.tsx
@@ -27,7 +27,9 @@ vi.mock("@/components/ui/TagList/TagList", () => ({
 }));
 
 vi.mock("@/utilities/Date", () => ({
-  datetimeToDate: (_date: string) => "2023-01-01",
+  yyyyMMddFormatter: {
+    format: () => "2023/01/01",
+  },
 }));
 
 describe("PostItem", () => {
@@ -54,7 +56,7 @@ describe("PostItem", () => {
 
   it("フォーマットされた公開日が表示されること", () => {
     const { getByText } = render(<PostItem post={mockPost} />);
-    expect(getByText("2023-01-01")).toBeInTheDocument();
+    expect(getByText("2023/01/01")).toBeInTheDocument();
   });
 
   it("投稿のスラッグを含む正しいリンクが含まれること", () => {

--- a/src/components/features/post/PostList/PostItem/PostItem.tsx
+++ b/src/components/features/post/PostList/PostItem/PostItem.tsx
@@ -3,12 +3,12 @@ import { clsx } from "clsx";
 import { AnchorLink } from "@/components/ui/link/AnchorLink/AnchorLink";
 import { TagList } from "@/components/ui/TagList/TagList";
 import { ROUTE } from "@/constants/route";
-import { datetimeToDate } from "@/utilities/Date";
+import { yyyyMMddFormatter } from "@/utilities/Date";
 
 import type { Props } from "./type";
 
 export const PostItem = ({ post }: Props) => {
-  const pubDate = datetimeToDate(post.publishedAt);
+  const pubDate = yyyyMMddFormatter.format(new Date(post.publishedAt));
 
   return (
     <article>

--- a/src/components/page/PostDetail/PostDetail.tsx
+++ b/src/components/page/PostDetail/PostDetail.tsx
@@ -10,12 +10,12 @@ import { Heading } from "@/components/ui/Heading/Heading";
 import { TagList } from "@/components/ui/TagList/TagList";
 import { AdsenseClient, AdsenseUnits } from "@/constants/google";
 import { ROUTE } from "@/constants/route";
-import { datetimeToDate } from "@/utilities/Date";
+import { yyyyMMddFormatter } from "@/utilities/Date";
 
 import type { PostProps } from "./type";
 
 export const PostDetailPage = ({ post, relatedPosts }: PostProps) => {
-  const pubDate = datetimeToDate(post.publishedAt);
+  const pubDate = yyyyMMddFormatter.format(new Date(post.publishedAt));
 
   return (
     <CommonLayout>

--- a/src/utilities/Date.test.ts
+++ b/src/utilities/Date.test.ts
@@ -1,0 +1,11 @@
+import { datetimeToDate } from "./Date";
+
+describe("datetimeToDate", () => {
+  it("日付をyyyy.MM.dd形式に変換すること", () => {
+    expect(datetimeToDate("2026-06-06T00:00:00.000Z")).toBe("2026.06.06");
+  });
+
+  it("月日が1桁の場合にゼロ埋めすること", () => {
+    expect(datetimeToDate("2026-01-09T00:00:00.000Z")).toBe("2026.01.09");
+  });
+});

--- a/src/utilities/Date.test.ts
+++ b/src/utilities/Date.test.ts
@@ -1,11 +1,11 @@
-import { datetimeToDate } from "./Date";
+import { yyyyMMddFormatter } from "./Date";
 
-describe("datetimeToDate", () => {
-  it("日付をJSTのyyyy.MM.dd形式に変換すること", () => {
-    expect(datetimeToDate("2026-06-05T15:00:00.000Z")).toBe("2026.06.06");
+describe("yyyyMMddFormatter", () => {
+  it("日付をJSTのyyyy/MM/dd形式に変換すること", () => {
+    expect(yyyyMMddFormatter.format(new Date("2026-06-05T15:00:00.000Z"))).toBe("2026/06/06");
   });
 
   it("月日が1桁の場合にゼロ埋めすること", () => {
-    expect(datetimeToDate("2026-01-09T00:00:00.000Z")).toBe("2026.01.09");
+    expect(yyyyMMddFormatter.format(new Date("2026-01-09T00:00:00.000Z"))).toBe("2026/01/09");
   });
 });

--- a/src/utilities/Date.test.ts
+++ b/src/utilities/Date.test.ts
@@ -1,8 +1,8 @@
 import { datetimeToDate } from "./Date";
 
 describe("datetimeToDate", () => {
-  it("日付をyyyy.MM.dd形式に変換すること", () => {
-    expect(datetimeToDate("2026-06-06T00:00:00.000Z")).toBe("2026.06.06");
+  it("日付をJSTのyyyy.MM.dd形式に変換すること", () => {
+    expect(datetimeToDate("2026-06-05T15:00:00.000Z")).toBe("2026.06.06");
   });
 
   it("月日が1桁の場合にゼロ埋めすること", () => {

--- a/src/utilities/Date.ts
+++ b/src/utilities/Date.ts
@@ -1,5 +1,13 @@
 export function datetimeToDate(date: string): string {
-  const d = new Date(date);
+  const parts = new Intl.DateTimeFormat("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(date));
 
-  return `${d.getFullYear()}.${d.getMonth() + 1}.${d.getDate()}`;
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = parts.find((part) => part.type === "month")?.value ?? "";
+  const day = parts.find((part) => part.type === "day")?.value ?? "";
+
+  return `${year}.${month}.${day}`;
 }

--- a/src/utilities/Date.ts
+++ b/src/utilities/Date.ts
@@ -3,6 +3,7 @@ export function datetimeToDate(date: string): string {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
+    timeZone: "Asia/Tokyo",
   }).formatToParts(new Date(date));
 
   const year = parts.find((part) => part.type === "year")?.value ?? "";

--- a/src/utilities/Date.ts
+++ b/src/utilities/Date.ts
@@ -1,14 +1,6 @@
-export function datetimeToDate(date: string): string {
-  const parts = new Intl.DateTimeFormat("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    timeZone: "Asia/Tokyo",
-  }).formatToParts(new Date(date));
-
-  const year = parts.find((part) => part.type === "year")?.value ?? "";
-  const month = parts.find((part) => part.type === "month")?.value ?? "";
-  const day = parts.find((part) => part.type === "day")?.value ?? "";
-
-  return `${year}.${month}.${day}`;
-}
+export const yyyyMMddFormatter = new Intl.DateTimeFormat("ja-JP", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  timeZone: "Asia/Tokyo",
+});


### PR DESCRIPTION
resolve #1511 

### Motivation
- Ensure `datetimeToDate` returns dates in the `yyyy.MM.dd` format with zero-padded month and day across locales.
- Add unit tests to prevent regressions for single-digit months/days.

### Description
- Replace manual `Date` numeric access in `datetimeToDate` with `Intl.DateTimeFormat(...).formatToParts` to obtain zero-padded `year`, `month`, and `day` parts and compose the result as `year.month.day`.
- Add `src/utilities/Date.test.ts` with two tests that assert `datetimeToDate` produces `"2026.06.06"` and zero-pads single-digit month/day (`"2026.01.09"`).

### Testing
- Ran unit tests with `npm test` (project test runner) and the test suite including `src/utilities/Date.test.ts` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d97b89f4832db8c160fc9812f7b6)