### PR TITLE
[codex] タグ一覧の不正なページ番号を404にする

### DIFF
--- a/src/app/post/tags/[slug]/[offset]/page.tsx
+++ b/src/app/post/tags/[slug]/[offset]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { cache } from "react";
 
 import { TagListPage } from "@/components/page/TagList/TagList";
-import { calcMaxPage, calcOffset } from "@/components/ui/Pager/util";
+import { calcMaxPage, calcOffset, parsePageNum } from "@/components/ui/Pager/util";
 import { ROUTE } from "@/constants/route";
 import { SITE } from "@/constants/site";
 import { getByTagId, getTagBySlug, POST_PER_PAGE } from "@/libs/microcms";
@@ -18,7 +18,16 @@ type PageParams = {
 export const dynamic = "force-dynamic";
 
 const fetchData = cache(async ({ slug, offset: offsetParam }: Awaited<PageParams["params"]>) => {
-  const pageNum = parseInt(offsetParam, 10);
+  const pageNum = parsePageNum(offsetParam);
+  if (!pageNum) {
+    return {
+      tag: undefined,
+      posts: [],
+      maxPage: 0,
+      pageNum: 0,
+    };
+  }
+
   // Tag check
   const Tags = await getTagBySlug(slug);
   if (Tags.contents.length === 0) {
@@ -38,6 +47,14 @@ const fetchData = cache(async ({ slug, offset: offsetParam }: Awaited<PageParams
   const posts = PostMapper.list(response.contents);
 
   const maxPage = calcMaxPage(response.totalCount, POST_PER_PAGE);
+  if (pageNum > maxPage) {
+    return {
+      tag: undefined,
+      posts: [],
+      maxPage,
+      pageNum,
+    };
+  }
 
   return {
     tag: Tag,
@@ -54,7 +71,7 @@ export const generateMetadata = async (props: PageParams) => {
   const { slug: slugParam } = params;
   const res = await fetchData({
     slug: slugParam,
-    offset: "0",
+    offset: "1",
   });
   if (!res.tag) {
     return {};

--- a/src/app/post/tags/[slug]/[offset]/page.tsx
+++ b/src/app/post/tags/[slug]/[offset]/page.tsx
@@ -41,12 +41,8 @@ const fetchData = cache(async ({ slug, offset: offsetParam }: Awaited<PageParams
   const Tag = Tags.contents[0];
 
   // Post Check
-  const offset = calcOffset(pageNum, POST_PER_PAGE);
-
-  const response = await getByTagId(Tag.id, POST_PER_PAGE, offset);
-  const posts = PostMapper.list(response.contents);
-
-  const maxPage = calcMaxPage(response.totalCount, POST_PER_PAGE);
+  const tagPostsSummary = await getByTagId(Tag.id, 1, 0);
+  const maxPage = Math.max(calcMaxPage(tagPostsSummary.totalCount, POST_PER_PAGE), 1);
   if (pageNum > maxPage) {
     return {
       tag: undefined,
@@ -55,6 +51,10 @@ const fetchData = cache(async ({ slug, offset: offsetParam }: Awaited<PageParams
       pageNum,
     };
   }
+
+  const offset = calcOffset(pageNum, POST_PER_PAGE);
+  const response = await getByTagId(Tag.id, POST_PER_PAGE, offset);
+  const posts = PostMapper.list(response.contents);
 
   return {
     tag: Tag,

--- a/src/app/post/tags/[slug]/[offset]/page.tsx
+++ b/src/app/post/tags/[slug]/[offset]/page.tsx
@@ -17,47 +17,61 @@ type PageParams = {
 
 export const dynamic = "force-dynamic";
 
-const fetchData = cache(async ({ slug, offset: offsetParam }: Awaited<PageParams["params"]>) => {
-  const pageNum = parsePageNum(offsetParam);
-  if (!pageNum) {
-    return {
-      tag: undefined,
-      posts: [],
-      maxPage: 0,
-      pageNum: 0,
-    };
-  }
+const fetchTagPageInfo = cache(
+  async ({ slug, offset: offsetParam }: Awaited<PageParams["params"]>) => {
+    const pageNum = parsePageNum(offsetParam, POST_PER_PAGE);
+    if (!pageNum) {
+      return {
+        tag: undefined,
+        maxPage: 0,
+        pageNum: 0,
+      };
+    }
 
-  // Tag check
-  const Tags = await getTagBySlug(slug);
-  if (Tags.contents.length === 0) {
-    return {
-      tag: undefined,
-      posts: [],
-      maxPage: 0,
-      pageNum: 0,
-    };
-  }
-  const Tag = Tags.contents[0];
+    const Tags = await getTagBySlug(slug);
+    if (Tags.contents.length === 0) {
+      return {
+        tag: undefined,
+        maxPage: 0,
+        pageNum: 0,
+      };
+    }
+    const Tag = Tags.contents[0];
 
-  // Post Check
-  const tagPostsSummary = await getByTagId(Tag.id, 1, 0);
-  const maxPage = Math.max(calcMaxPage(tagPostsSummary.totalCount, POST_PER_PAGE), 1);
-  if (pageNum > maxPage) {
+    const tagPostsSummary = await getByTagId(Tag.id, 1, 0);
+    const maxPage = Math.max(calcMaxPage(tagPostsSummary.totalCount, POST_PER_PAGE), 1);
+    if (pageNum > maxPage) {
+      return {
+        tag: undefined,
+        maxPage,
+        pageNum,
+      };
+    }
+
     return {
-      tag: undefined,
-      posts: [],
+      tag: Tag,
       maxPage,
       pageNum,
     };
   }
+);
 
+const fetchData = cache(async (params: Awaited<PageParams["params"]>) => {
+  const tagPageInfo = await fetchTagPageInfo(params);
+  if (!tagPageInfo.tag) {
+    return {
+      ...tagPageInfo,
+      posts: [],
+    };
+  }
+
+  const { tag, maxPage, pageNum } = tagPageInfo;
   const offset = calcOffset(pageNum, POST_PER_PAGE);
-  const response = await getByTagId(Tag.id, POST_PER_PAGE, offset);
+  const response = await getByTagId(tag.id, POST_PER_PAGE, offset);
   const posts = PostMapper.list(response.contents);
 
   return {
-    tag: Tag,
+    tag,
     posts,
     maxPage,
     pageNum,
@@ -68,11 +82,7 @@ export const dynamicParams = true;
 
 export const generateMetadata = async (props: PageParams) => {
   const params = await props.params;
-  const { slug: slugParam } = params;
-  const res = await fetchData({
-    slug: slugParam,
-    offset: "1",
-  });
+  const res = await fetchTagPageInfo(params);
   if (!res.tag) {
     return {};
   }

--- a/src/components/ui/Pager/Pager.test.tsx
+++ b/src/components/ui/Pager/Pager.test.tsx
@@ -65,30 +65,30 @@ describe("ページ番号パースのテスト", () => {
 afterEach(cleanup);
 
 describe("ページャーの表示", () => {
-  it("1/1の時、表示されないこと", async () => {
-    const { queryByTestId } = render(<Pager basePath="" pageNum={1} maxPage={1} />);
+  it("1/1の時、表示されないこと", () => {
+    const { queryByRole } = render(<Pager basePath="" pageNum={1} maxPage={1} />);
 
-    expect(queryByTestId("prev")).toBeFalsy();
-    expect(queryByTestId("next")).toBeFalsy();
+    expect(queryByRole("link", { name: "前のページへ" })).toBeFalsy();
+    expect(queryByRole("link", { name: "次のページへ" })).toBeFalsy();
   });
 
-  it("2/2の時、前のページへが表示される", async () => {
-    const { findByTestId, queryByTestId } = render(<Pager basePath="" pageNum={2} maxPage={2} />);
+  it("2/2の時、前のページへが表示される", () => {
+    const { getByRole, queryByRole } = render(<Pager basePath="" pageNum={2} maxPage={2} />);
 
-    expect(findByTestId("prev")).toBeTruthy();
-    expect(queryByTestId("next")).toBeFalsy();
+    expect(getByRole("link", { name: "前のページへ" })).toBeTruthy();
+    expect(queryByRole("link", { name: "次のページへ" })).toBeFalsy();
   });
 
-  it("1/2の時、次のページへが表示される", async () => {
-    const { findByTestId, queryByTestId } = render(<Pager basePath="" pageNum={1} maxPage={2} />);
+  it("1/2の時、次のページへが表示される", () => {
+    const { getByRole, queryByRole } = render(<Pager basePath="" pageNum={1} maxPage={2} />);
 
-    expect(findByTestId("next")).toBeTruthy();
-    expect(queryByTestId("prev")).toBeFalsy();
+    expect(getByRole("link", { name: "次のページへ" })).toBeTruthy();
+    expect(queryByRole("link", { name: "前のページへ" })).toBeFalsy();
   });
 
   it("最大ページを超えている時、次のページへが表示されない", () => {
-    const { queryByTestId } = render(<Pager basePath="" pageNum={3} maxPage={2} />);
+    const { queryByRole } = render(<Pager basePath="" pageNum={3} maxPage={2} />);
 
-    expect(queryByTestId("next")).toBeFalsy();
+    expect(queryByRole("link", { name: "次のページへ" })).toBeFalsy();
   });
 });

--- a/src/components/ui/Pager/Pager.test.tsx
+++ b/src/components/ui/Pager/Pager.test.tsx
@@ -50,6 +50,16 @@ describe("ページ番号パースのテスト", () => {
     expect(parsePageNum("1abc")).toBeUndefined();
     expect(parsePageNum("1.5")).toBeUndefined();
   });
+
+  it("十進整数表現ではないページ番号は不正値にする", () => {
+    expect(parsePageNum("1e2")).toBeUndefined();
+    expect(parsePageNum(" 1")).toBeUndefined();
+    expect(parsePageNum("01")).toBeUndefined();
+  });
+
+  it("安全に扱えない整数は不正値にする", () => {
+    expect(parsePageNum("9007199254740993")).toBeUndefined();
+  });
 });
 
 afterEach(cleanup);

--- a/src/components/ui/Pager/Pager.test.tsx
+++ b/src/components/ui/Pager/Pager.test.tsx
@@ -60,6 +60,10 @@ describe("ページ番号パースのテスト", () => {
   it("安全に扱えない整数は不正値にする", () => {
     expect(parsePageNum("9007199254740993")).toBeUndefined();
   });
+
+  it("offsetを安全に扱えないページ番号は不正値にする", () => {
+    expect(parsePageNum("9007199254740991", POST_PER_PAGE)).toBeUndefined();
+  });
 });
 
 afterEach(cleanup);

--- a/src/components/ui/Pager/Pager.test.tsx
+++ b/src/components/ui/Pager/Pager.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render } from "@testing-library/react";
 
 import { Pager } from "./Pager";
-import { calcMaxPage, calcOffset } from "./util";
+import { calcMaxPage, calcOffset, parsePageNum } from "./util";
 
 const POST_PER_PAGE = 12;
 
@@ -34,6 +34,24 @@ describe("MaxPageのテスト", () => {
   });
 });
 
+describe("ページ番号パースのテスト", () => {
+  it("1以上の整数をページ番号として返す", () => {
+    expect(parsePageNum("1")).toBe(1);
+    expect(parsePageNum("2")).toBe(2);
+  });
+
+  it("1未満のページ番号は不正値にする", () => {
+    expect(parsePageNum("0")).toBeUndefined();
+    expect(parsePageNum("-1")).toBeUndefined();
+  });
+
+  it("整数ではないページ番号は不正値にする", () => {
+    expect(parsePageNum("abc")).toBeUndefined();
+    expect(parsePageNum("1abc")).toBeUndefined();
+    expect(parsePageNum("1.5")).toBeUndefined();
+  });
+});
+
 afterEach(cleanup);
 
 describe("ページャーの表示", () => {
@@ -56,5 +74,11 @@ describe("ページャーの表示", () => {
 
     expect(findByTestId("next")).toBeTruthy();
     expect(queryByTestId("prev")).toBeFalsy();
+  });
+
+  it("最大ページを超えている時、次のページへが表示されない", () => {
+    const { queryByTestId } = render(<Pager basePath="" pageNum={3} maxPage={2} />);
+
+    expect(queryByTestId("next")).toBeFalsy();
   });
 });

--- a/src/components/ui/Pager/Pager.tsx
+++ b/src/components/ui/Pager/Pager.tsx
@@ -21,7 +21,7 @@ export const Pager = ({ basePath, pageNum, maxPage }: PagerProps) => {
         <div></div>
       )}
 
-      {pageNum !== maxPage ? (
+      {pageNum < maxPage ? (
         <ButtonLink label="次のページへ" link={`${basePath}/${nextPageNum}`} data-testid="next" />
       ) : (
         <div></div>

--- a/src/components/ui/Pager/util.ts
+++ b/src/components/ui/Pager/util.ts
@@ -23,7 +23,7 @@ export function calcMaxPage(totalCount: number, postPerPage: number): number {
   return Math.ceil(totalCount / postPerPage);
 }
 
-export function parsePageNum(pageNumParam: string): number | undefined {
+export function parsePageNum(pageNumParam: string, postPerPage?: number): number | undefined {
   if (!/^[1-9]\d*$/.test(pageNumParam)) {
     return undefined;
   }
@@ -31,6 +31,10 @@ export function parsePageNum(pageNumParam: string): number | undefined {
   const pageNum = Number(pageNumParam);
 
   if (!Number.isSafeInteger(pageNum)) {
+    return undefined;
+  }
+
+  if (postPerPage && !Number.isSafeInteger(calcOffset(pageNum, postPerPage))) {
     return undefined;
   }
 

--- a/src/components/ui/Pager/util.ts
+++ b/src/components/ui/Pager/util.ts
@@ -24,9 +24,13 @@ export function calcMaxPage(totalCount: number, postPerPage: number): number {
 }
 
 export function parsePageNum(pageNumParam: string): number | undefined {
+  if (!/^[1-9]\d*$/.test(pageNumParam)) {
+    return undefined;
+  }
+
   const pageNum = Number(pageNumParam);
 
-  if (!Number.isInteger(pageNum) || pageNum < 1) {
+  if (!Number.isSafeInteger(pageNum)) {
     return undefined;
   }
 

--- a/src/components/ui/Pager/util.ts
+++ b/src/components/ui/Pager/util.ts
@@ -22,3 +22,13 @@ export function calcOffset(currnetPageNum: number, postPerPage: number): number 
 export function calcMaxPage(totalCount: number, postPerPage: number): number {
   return Math.ceil(totalCount / postPerPage);
 }
+
+export function parsePageNum(pageNumParam: string): number | undefined {
+  const pageNum = Number(pageNumParam);
+
+  if (!Number.isInteger(pageNum) || pageNum < 1) {
+    return undefined;
+  }
+
+  return pageNum;
+}


### PR DESCRIPTION
## 概要

タグ指定の記事一覧ページで、不正なページ番号や最大ページ超過を 404 扱いにするよう修正しました。

## 変更内容

- `0`、負数、非整数、文字列混在などのページ番号を不正値として扱う `parsePageNum` を追加
- タグ一覧ページで不正なページ番号を `notFound()` に流すよう修正
- タグ一覧ページで最大ページを超えたページ番号を 404 扱いにするよう修正
- `Pager` で `pageNum < maxPage` の場合のみ「次のページへ」を表示するよう修正
- ページ番号パースと最大ページ超過時の表示テストを追加

## 背景

これまでは `/post/tags/{slug}/0` や `/post/tags/{slug}/abc` のような URL が 1ページ目相当として扱われたり、最大ページを超えた場合でも次ページリンクが表示される可能性がありました。

## 確認内容

- `pnpm type-check`
- `pnpm check`
- `pnpm test`

`pnpm test` では既存の Hatena 外部スクリプト読み込み警告が出ますが、テストは成功しています。
